### PR TITLE
Added boost NuGet package as dependency

### DIFF
--- a/LiteLockr.vcxproj
+++ b/LiteLockr.vcxproj
@@ -431,10 +431,20 @@
     <ClInclude Include="src\sys\StringUtils.h" />
     <ClInclude Include="src\sys\Time.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="packages\boost.1.86.0\build\boost.targets" Condition="Exists('packages\boost.1.86.0\build\boost.targets')" />
   </ImportGroup>
   <PropertyGroup Condition="'$(Language)'=='C++'">
     <CAExcludePath>ext;$(BoostRootDir);$(CAExcludePath)</CAExcludePath>
   </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\boost.1.86.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\boost.1.86.0\build\boost.targets'))" />
+  </Target>
 </Project>

--- a/LiteLockr.vcxproj.filters
+++ b/LiteLockr.vcxproj.filters
@@ -1110,4 +1110,7 @@
       <Filter>Resource Files</Filter>
     </Media>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.86.0" targetFramework="native" />
+</packages>


### PR DESCRIPTION
This will prompt the user to run `NuGet Package Restore` to download the `boost` libraries if they are missing.